### PR TITLE
removed unused fhheader directove FHTEMPLATE-8

### DIFF
--- a/www/app/directives.js
+++ b/www/app/directives.js
@@ -2,22 +2,6 @@
 
 var myApp = angular.module('myApp.directives', []);
 
-myApp.directive('fhheader', function() {
-    return {
-        scope: {},
-        restrict: 'E',
-        replace: true,
-        templateUrl: 'views/components/header.html',
-        link: function(scope, elem, attrs, ctrl) {
-            var headerProps = {
-                title: attrs.title,
-                subtext: attrs.subtext
-            };
-            scope.title = headerProps;
-        }
-    };
-});
-
 myApp.directive('fhfooter', function() {
     return {
         scope: {},


### PR DESCRIPTION
The directive is not used anywhere, seems like copy&paste from `quickstart-angular-app`

https://issues.jboss.org/browse/FHTEMPLATE-8