### PR TITLE
RHMAP-15494 - update template as part of node 6 update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ services:
   - mongodb
   - docker
 node_js:
-  - "0.10"
   - "4.4.3"
+  - "6.9.1"
 before_install:
   - npm install fh-build -g
   - fh-build template

--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ You can also use Grunt to point your App at a local developement server. To do t
 
 * you can also pass a 'url' optional flag to server:local, e.g. ```grunt serve:local --url=http://localhost:9000```
 
-* We can also write your own tasks by extending the Gruntfile.js, e.g. add a 'serve:live' target that hits your server in your FeedHenry live enivronment.
+* you can also write your own tasks by extending the Gruntfile.js, e.g. add a 'serve:live' target that hits your server in your FeedHenry live enivronment.

--- a/package.json
+++ b/package.json
@@ -31,5 +31,5 @@
   "scripts": {
     "install": "./node_modules/grunt-cli/bin/grunt browserify"
   },
-  "license": "mit"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
## Motivation
Verify that the Quickstart-Ionic-App could run with node 6 and that the readme was up to date.

## Result

- Updated `travis.yml` file => remove node 0.10 and added node 6.9.1

- Small typo fix in `README.md`.

- Updated the license in `package.json`

## Jira
https://issues.jboss.org/browse/RHMAP-15494